### PR TITLE
Replace implementation of Guess from namedtuple to a proper object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ The date guesser uses both the url and the html to work, and uses some heuristic
     guess = guess_date(url='https://www.nytimes.com/2017/10/13/some_news.html', 
                        html='<could be anything></could>')
 
-    #  Returns a Guess object
+    #  Returns a date_guesser.constants.Guess object
     guess.date      # datetime.datetime(2017, 10, 13, 0, 0, tzinfo=<UTC>)
     guess.accuracy  # Accuracy.DATE
     guess.method    # 'Found /2017/10/13/ in url'

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ The date guesser uses both the url and the html to work, and uses some heuristic
     guess = guess_date(url='https://www.nytimes.com/2017/10/13/some_news.html', 
                        html='<could be anything></could>')
 
-    #  Returns a namedtuple with three fields
+    #  Returns a Guess object
     guess.date      # datetime.datetime(2017, 10, 13, 0, 0, tzinfo=<UTC>)
     guess.accuracy  # Accuracy.DATE
     guess.method    # 'Found /2017/10/13/ in url'

--- a/date_guesser/constants.py
+++ b/date_guesser/constants.py
@@ -1,4 +1,4 @@
-from enum import Enum, IntEnum
+from enum import IntEnum
 
 LOCALE = 'en'
 

--- a/date_guesser/constants.py
+++ b/date_guesser/constants.py
@@ -23,7 +23,7 @@ class Guess(object):
         '__method',
     ]
 
-    def __init__(self, date, accuracy = None, method = None):
+    def __init__(self, date, accuracy, method):
         self.__date = date
         self.__accuracy = accuracy
         self.__method = method

--- a/date_guesser/constants.py
+++ b/date_guesser/constants.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from enum import Enum, IntEnum
 
 LOCALE = 'en'
@@ -14,4 +13,32 @@ class Accuracy(IntEnum):
 
 NO_METHOD = 'Did not find anything'
 
-Guess = namedtuple('Guess', ('date', 'accuracy', 'method'))
+
+class Guess(object):
+    """Date guessing result for the provided URL and its HTML contents."""
+
+    __slots__ = [
+        '__date',
+        '__accuracy',
+        '__method',
+    ]
+
+    def __init__(self, date, accuracy = None, method = None):
+        self.__date = date
+        self.__accuracy = accuracy
+        self.__method = method
+
+    @property
+    def accuracy(self):
+        """Accuracy of the guess."""
+        return self.__accuracy
+
+    @property
+    def date(self):
+        """datetime.datetime object with the guessed date, or None if a guess can't be made."""
+        return self.__date
+
+    @property
+    def method(self):
+        """Method that was used for guessing the date, or None if a guess can't be made."""
+        return self.__method

--- a/date_guesser/guess_date.py
+++ b/date_guesser/guess_date.py
@@ -19,9 +19,7 @@ def guess_date(url, html):
 
     Returns
     -------
-    namedtuple: (datetime or None, Accuracy, str)
-        In case a reasonable guess can be made, returns a datetime, Enum of accuracy, and
-        string describing how the date was obtained
+    Guess object.
     """
     return DateGuesser().guess_date(url, html)
 
@@ -37,14 +35,14 @@ class DateGuesser(object):
 
         Attributes
         ----------
-        current : (datetime or None, Accuracy)
+        current : Guess object.
             Current datetime and accuracy
-        new : (datetime or None, Accuracy)
+        new : Guess object.
             Proposed datetime and accuracy
 
         Returns
         -------
-        (datetime or None, Accuracy)
+        Guess object.
             Either current or new
         """
         if current.accuracy >= new.accuracy:
@@ -71,16 +69,14 @@ class DateGuesser(object):
 
         Returns
         -------
-        namedtuple: (datetime or None, Accuracy, str)
-            In case a reasonable guess can be made, returns a datetime, Enum of accuracy, and
-            string describing how the date was obtained
+        Guess object.
         """
         reason_to_skip = filter_url_for_undateable(url)
         if reason_to_skip is not None:
             return reason_to_skip
 
         # default guess
-        guess = Guess(None, Accuracy.NONE, NO_METHOD)
+        guess = Guess(date=None, accuracy=Accuracy.NONE, method=NO_METHOD)
         # Try using the url
         guess = self._choose_better_guess(guess, parse_url_for_date(url))
 
@@ -89,7 +85,7 @@ class DateGuesser(object):
         for tag_checker in self.tag_checkers:
             date_string, method = tag_checker(soup)
             new_date, new_accuracy = self.parser.parse(date_string)
-            new_guess = Guess(new_date, new_accuracy, method)
+            new_guess = Guess(date=new_date, accuracy=new_accuracy, method=method)
             guess = self._choose_better_guess(guess, new_guess)
 
         # Try using an image tag
@@ -104,5 +100,5 @@ class DateGuesser(object):
         if image_url is not None:
             guess = parse_url_for_date(image_url)
             if guess is not None:
-                return Guess(guess.date, guess.accuracy, ', '.join([html_method, guess.method]))
-        return Guess(None, Accuracy.NONE, NO_METHOD)
+                return Guess(date=guess.date, accuracy=guess.accuracy, method=', '.join([html_method, guess.method]))
+        return Guess(date=None, accuracy=Accuracy.NONE, method=NO_METHOD)

--- a/date_guesser/guess_date.py
+++ b/date_guesser/guess_date.py
@@ -19,7 +19,7 @@ def guess_date(url, html):
 
     Returns
     -------
-    Guess object.
+    date_guesser.constants.Guess object.
     """
     return DateGuesser().guess_date(url, html)
 
@@ -35,14 +35,14 @@ class DateGuesser(object):
 
         Attributes
         ----------
-        current : Guess object.
+        current : date_guesser.constants.Guess object.
             Current datetime and accuracy
-        new : Guess object.
+        new : date_guesser.constants.Guess object.
             Proposed datetime and accuracy
 
         Returns
         -------
-        Guess object.
+        date_guesser.constants.Guess object.
             Either current or new
         """
         if current.accuracy >= new.accuracy:
@@ -69,7 +69,7 @@ class DateGuesser(object):
 
         Returns
         -------
-        Guess object.
+        date_guesser.constants.Guess object.
         """
         reason_to_skip = filter_url_for_undateable(url)
         if reason_to_skip is not None:

--- a/date_guesser/urls.py
+++ b/date_guesser/urls.py
@@ -53,7 +53,7 @@ def parse_url_for_date(url):
 
     Returns
     -------
-    Guess object.
+    date_guesser.constants.Guess object.
     """
     accuracy = Accuracy.NONE
     for captures, method in url_date_generator(url):
@@ -101,7 +101,7 @@ def filter_url_for_undateable(url):
 
     Returns
     -------
-    Guess object or None
+    date_guesser.constants.Guess object or None
         guess describing why the page is undateable or None if it might be dateable
     """
     parsed = urlparse(url)

--- a/date_guesser/urls.py
+++ b/date_guesser/urls.py
@@ -53,7 +53,7 @@ def parse_url_for_date(url):
 
     Returns
     -------
-    mediawords.date_guesser.constants.Guess
+    Guess object.
     """
     accuracy = Accuracy.NONE
     for captures, method in url_date_generator(url):
@@ -83,10 +83,10 @@ def parse_url_for_date(url):
 
         try:
             date_guess = datetime.datetime(tzinfo=pytz.utc, **captures)
-            return Guess(date_guess, accuracy, method)
+            return Guess(date=date_guess, accuracy=accuracy, method=method)
         except ValueError:
             pass
-    return Guess(None, Accuracy.NONE, NO_METHOD)
+    return Guess(date=None, accuracy=Accuracy.NONE, method=NO_METHOD)
 
 
 def filter_url_for_undateable(url):
@@ -101,7 +101,7 @@ def filter_url_for_undateable(url):
 
     Returns
     -------
-    mediawords.date_guesser.constants.Guess or None
+    Guess object or None
         guess describing why the page is undateable or None if it might be dateable
     """
     parsed = urlparse(url)
@@ -114,20 +114,23 @@ def filter_url_for_undateable(url):
 
     hostname = parsed.hostname
     if hostname is None:
-        return Guess(None, Accuracy.NONE, 'Invalid url ({})'.format(url[:200]))
+        return Guess(date=None, accuracy=Accuracy.NONE, method='Invalid url ({})'.format(url[:200]))
 
     elif hostname.endswith('wikipedia.org'):
-        return Guess(None, Accuracy.NONE, 'No date for wiki pages')
+        return Guess(date=None, accuracy=Accuracy.NONE, method='No date for wiki pages')
 
     elif hostname.endswith('twitter.com') and ('status' not in path_parts):
-        return Guess(None, Accuracy.NONE, 'Twitter, but not a single tweet')
+        return Guess(date=None, accuracy=Accuracy.NONE, method='Twitter, but not a single tweet')
 
     elif parsed.path.strip('/') == '':
-        return Guess(None, Accuracy.NONE,
-                    'Empty `path`, might be frontpage of {}'.format(hostname))
+        return Guess(
+            date=None,
+            accuracy=Accuracy.NONE,
+            method='Empty `path`, might be frontpage of {}'.format(hostname)
+        )
     path_contains = invalid_paths.intersection(path_parts)
     if path_contains:  # nonempty intersection is truthy
         bad_parts = ', '.join(['"{}"' for segment in path_contains])
-        return Guess(None, Accuracy.NONE, 'URL ({}) contains {}'.format(url, bad_parts) )
+        return Guess(date=None, accuracy=Accuracy.NONE, method='URL ({}) contains {}'.format(url, bad_parts) )
 
     return None


### PR DESCRIPTION
Hi Colin,

With `namedtuple`-based `Guess`, IDEs (such as PyCharm) and linters are unable to verify that accessed properties exist and emit a warning:

<img width="881" alt="screenshot 2018-01-24 17 51 16" src="https://user-images.githubusercontent.com/181949/35362413-3d118144-0133-11e8-9b51-004df29a9778.png">

I've made `Guess` into a boring, `object`-inheriting object that the IDE is able to cope with. Similar to `namedtuple` implementation, `Guess` properties remain to be read-only.

Should you choose to pull this change, could you please release a new version too?